### PR TITLE
add Swagger documentation for PaymentType API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/mipagina/payment_type_service/config/OpenAPIConfig.java
+++ b/src/main/java/com/mipagina/payment_type_service/config/OpenAPIConfig.java
@@ -1,0 +1,32 @@
+package com.mipagina.payment_type_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+    @Bean
+    public OpenAPI myOpenAPI() {
+        Contact contact = new Contact();
+        contact.setEmail("support@example.com");
+        contact.setName("API Support");
+        contact.setUrl("https://www.example.com");
+
+        License license = new License()
+                .name("Apache License 2.0")
+                .url("https://www.apache.org/licenses/LICENSE-2.0");
+
+        Info info = new Info()
+                .title("Payment Type API")
+                .version("1.0")
+                .contact(contact)
+                .description("This API manages different payment types.")
+                .license(license);
+
+        return new OpenAPI().info(info);
+    }
+}

--- a/src/main/java/com/mipagina/payment_type_service/controller/PaymentTypeController.java
+++ b/src/main/java/com/mipagina/payment_type_service/controller/PaymentTypeController.java
@@ -2,6 +2,11 @@ package com.mipagina.payment_type_service.controller;
 
 import com.mipagina.payment_type_service.model.PaymentType;
 import com.mipagina.payment_type_service.service.PaymentTypeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -9,36 +14,61 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/payment")
+@Tag(name = "PaymentType", description = "API for managing payment types")
 public class PaymentTypeController {
-
     @Autowired
     private PaymentTypeService paymentTypeService;
 
+    @Operation(summary = "Create a new payment type", description = "Stores a new payment type in the system")
+    @ApiResponse(responseCode = "201", description = "Payment method created successfully")
     @PostMapping("/create")
-    public String createPaymentId(@RequestBody PaymentType paymentType){
+    public String createPaymentId(@RequestBody PaymentType paymentType) {
         paymentTypeService.savePaymentType(paymentType);
         return "Payment method created successfully";
     }
 
+    @Operation(summary = "Retrieve all payment types", description = "Returns a list of all available payment types")
+    @ApiResponse(responseCode = "200", description = "List of payment types retrieved successfully")
     @GetMapping("/bringAll")
-    public List<PaymentType> getAllPaymentType(){
+    public List<PaymentType> getAllPaymentType() {
         return paymentTypeService.getAllPaymentType();
     }
 
+    @Operation(summary = "Retrieve a payment type by ID", description = "Fetches a payment type based on the provided ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Payment type retrieved successfully"),
+            @ApiResponse(responseCode = "404", description = "Payment type not found")
+    })
     @GetMapping("/bring/{paymentId}")
-    public PaymentType getPaymentType(@PathVariable Long paymentId){
+    public PaymentType getPaymentType(
+            @Parameter(description = "ID of the payment type to retrieve", required = true, example = "1")
+            @PathVariable Long paymentId) {
         return paymentTypeService.getPaymentType(paymentId);
     }
 
+    @Operation(summary = "Update a payment type", description = "Modifies an existing payment type")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Payment type updated successfully"),
+            @ApiResponse(responseCode = "404", description = "Payment type not found")
+    })
     @PutMapping("/edit/{paymentId}")
-    public String editPaymentType(@PathVariable Long paymentId,
-                                  @RequestBody PaymentType paymentType){
-        paymentTypeService.editPaymentType(paymentId,paymentType);
+    public String editPaymentType(
+            @Parameter(description = "ID of the payment type to edit", required = true, example = "1")
+            @PathVariable Long paymentId,
+            @RequestBody PaymentType paymentType) {
+        paymentTypeService.editPaymentType(paymentId, paymentType);
         return "Payment method edited correctly";
     }
 
+    @Operation(summary = "Delete a payment type", description = "Removes a payment type from the system")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Payment type deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Payment type not found")
+    })
     @DeleteMapping("/delete/{paymentId}")
-    public String deletePaymentType(@PathVariable Long paymentId){
+    public String deletePaymentType(
+            @Parameter(description = "ID of the payment type to delete", required = true, example = "1")
+            @PathVariable Long paymentId) {
         paymentTypeService.deletePaymentType(paymentId);
         return "Payment method deleted correctly";
     }

--- a/src/main/java/com/mipagina/payment_type_service/model/PaymentType.java
+++ b/src/main/java/com/mipagina/payment_type_service/model/PaymentType.java
@@ -1,15 +1,20 @@
 package com.mipagina.payment_type_service.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
+@Schema(description = "Entity representing a payment type")
 public class PaymentType {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "Unique identifier of the payment type", example = "1")
     private Long paymentId;
+
+    @Schema(description = "Type of payment", example = "Credit Card", required = true)
     private String paymentType;
 
     public Long getPaymentId() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,10 @@
 spring.application.name=payment-type-service
+server.port=8080
+
 eureka.client.service-url.defaultZone=http://localhost:8761/eureka
 
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://localhost:3306/payment_service?serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=admin
+spring.datasource.password=12345
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
This update improves the API documentation by adding Swagger annotations to the PaymentTypeController class, providing detailed descriptions for endpoints related to payment type management. These changes ensure better understanding for developers working with the PaymentType API.

Changes:
Added @Tag annotation to categorize the PaymentType API.
Documented all the endpoints (createPaymentId, getAllPaymentType, getPaymentType, editPaymentType, and deletePaymentType) with @Operation and @ApiResponse.
Provided detailed parameter descriptions for the paymentId path variable and paymentType request body using @Parameter.
Included response codes (200, 201, 404) to describe the expected outcomes for each operation.

Reviewer: @JuanGuevara90